### PR TITLE
Siisti bibtexin serialisointi

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Sovellus löytyy osoitteesta https://ateam-bibtex-generator.herokuapp.com/
 [![Build Status](https://travis-ci.org/joomoz/A-team.svg?branch=master)](https://travis-ci.org/joomoz/A-team)
 [![Coverage Status](https://coveralls.io/repos/github/joomoz/A-team/badge.svg?branch=master)](https://coveralls.io/github/joomoz/A-team?branch=master)
 [![Code Climate](https://codeclimate.com/github/joomoz/A-team.png)](https://codeclimate.com/github/joomoz/A-team)
+

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -19,33 +19,15 @@ class Reference < ActiveRecord::Base
     self.key = key
   end
 
-  def to_s
-    "@#{entry_type}{#{key},
-      author = {#{author}},
-      title = {#{title}},
-      journal = {#{journal}},
-      volume = {#{volume}},
-      number = {#{number}},
-      month = {#{month}},
-      year = {#{year}},
-      pages = {#{pages}},
-      publisher = {#{publisher}},
-      editor = {#{editor}},
-      booktitle = {#{booktitle}},
-      organization = {#{organization}},
-      address = {#{address}},
-      note = {#{note}},
-      edition = {#{edition}},
-      series = {#{series}},
-      annote = {#{annote}},
-      chapter = {#{chapter}},
-      crossref = {#{crossref}},
-      howpublished = {#{howpublished}},
-      institution = {#{institution}},
-      school = {#{school}},
-      type = {#{type}},
-}
-"
+  def serialized_fields
+    [:author, :title, :journal, :volume, :number, :month, :year, :pages, :publisher, :editor, :booktitle, :organization, :address, :note, :edition, :series, :annote, :chapter, :crossref, :howpublished, :institution, :school, :type] 
+  end
 
+  def to_s
+    str = "@#{entry_type}{#{key},\n"
+    serialized_fields.each do |field|
+      str += "      #{field.to_s} = {#{self[field]}},\n" # unless self[field].blank?
+    end
+    str += "}\n"
   end
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -26,7 +26,7 @@ class Reference < ActiveRecord::Base
   def to_s
     str = "@#{entry_type}{#{key},\n"
     serialized_fields.each do |field|
-      str += "      #{field.to_s} = {#{self[field]}},\n" # unless self[field].blank?
+      str += "      #{field.to_s} = {#{self[field]}},\n" unless self[field].blank?
     end
     str += "}\n"
   end


### PR DESCRIPTION
Muutin bibtexin serialisointia siten, että se iteroi referencen kentät ja tulostaa niiden nimet ja arvot.
Nyt tyhjien kenttien poisto on helppoa.